### PR TITLE
Footer

### DIFF
--- a/src/components/app/app.js
+++ b/src/components/app/app.js
@@ -4,6 +4,7 @@ import { ThemeProvider } from 'styled-components';
 import { Normalize } from 'styled-normalize';
 import theme from '../../theme';
 import Header from '../header';
+import Footer from '../footer';
 import GlobalStyle from '../global-style';
 import * as S from './app.style';
 
@@ -23,6 +24,7 @@ const App = () => (
             Search
           </Route>
         </Switch>
+        <Footer />
       </S.Wrapper>
     </ThemeProvider>
   </Router>

--- a/src/components/footer/footer.js
+++ b/src/components/footer/footer.js
@@ -1,13 +1,12 @@
 import React from 'react';
-import { Link } from 'react-router-dom';
 import Logo from '../logo';
 import * as S from './footer.style';
 
 const Footer = () => (
   <S.Footer>
-    <a href="https://profy.dev/employers">profy.dev</a>
+    <S.ProfyLink href="https://profy.dev/employers">profy.dev</S.ProfyLink>
     <Logo asMark />
-    <Link to="/terms">Terms & Privacy</Link>
+    <S.TermsLink to="/terms">Terms & Privacy</S.TermsLink>
   </S.Footer>
 );
 

--- a/src/components/footer/footer.js
+++ b/src/components/footer/footer.js
@@ -1,0 +1,14 @@
+import React from 'react';
+import { Link } from 'react-router-dom';
+import Logo from '../logo';
+import * as S from './footer.style';
+
+const Footer = () => (
+  <S.Footer>
+    <a href="https://profy.dev/employers">profy.dev</a>
+    <Logo asMark />
+    <Link to="/terms">Terms & Privacy</Link>
+  </S.Footer>
+);
+
+export default Footer;

--- a/src/components/footer/footer.style.js
+++ b/src/components/footer/footer.style.js
@@ -4,8 +4,11 @@ import { Link } from 'react-router-dom';
 export const Footer = styled.footer`
   display: flex;
   align-items: center;
-  height: 6.25rem; /* 100px */
   font-size: 0.875rem;
+  height: 6.25rem; /* 100px */
+  margin: auto;
+  max-width: 61.25rem; /* 980px */
+  padding: 0 1.25rem; /* 20px */
 `;
 
 export const ProfyLink = styled.a`

--- a/src/components/footer/footer.style.js
+++ b/src/components/footer/footer.style.js
@@ -1,0 +1,9 @@
+import styled from 'styled-components';
+
+export const Footer = styled.footer`
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  height: 6.25rem; /* 100px */
+  font-size: 0.875rem;
+`;

--- a/src/components/footer/footer.style.js
+++ b/src/components/footer/footer.style.js
@@ -1,9 +1,18 @@
 import styled from 'styled-components';
+import { Link } from 'react-router-dom';
 
 export const Footer = styled.footer`
   display: flex;
   align-items: center;
-  justify-content: space-between;
   height: 6.25rem; /* 100px */
   font-size: 0.875rem;
+`;
+
+export const ProfyLink = styled.a`
+  flex: 1;
+`;
+
+export const TermsLink = styled(Link)`
+  flex: 1;
+  text-align: right;
 `;

--- a/src/components/footer/footer.test.js
+++ b/src/components/footer/footer.test.js
@@ -1,0 +1,16 @@
+import React from 'react';
+import { render, fireEvent } from '../../test-utils';
+import Footer from './footer';
+
+describe('footer', () => {
+  it('routes terms link', () => {
+    const { getByRole, history } = render(<Footer />);
+    const spyHistoryPush = jest.spyOn(history, 'push');
+
+    fireEvent.click(getByRole('link', { name: /terms & privacy/i }));
+
+    expect(spyHistoryPush).toHaveBeenCalledWith('/terms');
+
+    spyHistoryPush.mockRestore();
+  });
+});

--- a/src/components/footer/index.js
+++ b/src/components/footer/index.js
@@ -1,0 +1,1 @@
+export { default } from './footer';

--- a/src/components/global-style/global-style.js
+++ b/src/components/global-style/global-style.js
@@ -35,6 +35,14 @@ const GlobalStyle = createGlobalStyle`
     text-decoration: none;
     transition: color 0.2s ease-in-out;
   }
+
+  header a, footer a {
+    color: ${(props) => props.theme.colors.link.nav[0]};
+
+    &:hover {
+      color: ${(props) => props.theme.colors.link.nav[1]}
+    }
+  }
 `;
 
 export default GlobalStyle;

--- a/src/components/header/header.style.js
+++ b/src/components/header/header.style.js
@@ -13,12 +13,7 @@ export const Nav = styled.nav`
 `;
 
 export const NavLink = styled(Link)`
-  color: ${(props) => props.theme.colors.link.nav[0]};
   margin-right: 1.563rem; /* 25px */
-
-  &:hover {
-    color: ${(props) => props.theme.colors.link.nav[1]}
-  }
 
   &:last-of-type { margin-right: 0; }
 `;

--- a/src/components/header/header.test.js
+++ b/src/components/header/header.test.js
@@ -1,18 +1,18 @@
 import React from 'react';
-import { Router } from 'react-router-dom';
-import { fireEvent } from '@testing-library/react';
-import { createMemoryHistory } from 'history';
-import { render } from '../../test-utils';
+import { render, fireEvent } from '../../test-utils';
 import Header from './header';
 
 describe('header', () => {
   let header = null;
-  let history = null;
+  let spyHistoryPush = null;
 
   beforeEach(() => {
-    history = createMemoryHistory();
-    history.push = jest.fn();
-    header = render(<Router history={history}><Header /></Router>);
+    header = render(<Header />);
+    spyHistoryPush = jest.spyOn(header.history, 'push');
+  });
+
+  afterEach(() => {
+    spyHistoryPush.mockRestore();
   });
 
   it('routes how-it-works link', () => {
@@ -20,7 +20,7 @@ describe('header', () => {
 
     fireEvent.click(getByRole('link', { name: /how it works/i }));
 
-    expect(history.push).toHaveBeenCalledWith('/#how-it-works');
+    expect(spyHistoryPush).toHaveBeenCalledWith('/#how-it-works');
   });
 
   it('routes about link', () => {
@@ -28,7 +28,7 @@ describe('header', () => {
 
     fireEvent.click(getByRole('link', { name: /about/i }));
 
-    expect(history.push).toHaveBeenCalledWith('/#about');
+    expect(spyHistoryPush).toHaveBeenCalledWith('/#about');
   });
 
   it('routes search link with \'javascript\' url param', () => {
@@ -36,6 +36,6 @@ describe('header', () => {
 
     fireEvent.click(getByRole('link', { name: /search/i }));
 
-    expect(history.push).toHaveBeenCalledWith('/search/javascript');
+    expect(spyHistoryPush).toHaveBeenCalledWith('/search/javascript');
   });
 });

--- a/src/components/logo/logo.test.js
+++ b/src/components/logo/logo.test.js
@@ -1,0 +1,16 @@
+import React from 'react';
+import Logo from './logo';
+import { render, fireEvent } from '../../test-utils';
+
+describe('logo', () => {
+  it('routes to homepage', () => {
+    const { getByRole, history } = render(<Logo />);
+    const spyHistoryPush = jest.spyOn(history, 'push');
+
+    fireEvent.click(getByRole('link', { name: /logo/i }));
+
+    expect(spyHistoryPush).toHaveBeenCalledWith('/');
+
+    spyHistoryPush.mockRestore();
+  });
+});

--- a/src/test-utils.js
+++ b/src/test-utils.js
@@ -1,15 +1,25 @@
 import React from 'react';
+import { Router } from 'react-router-dom';
+import { createMemoryHistory } from 'history';
 import { render } from '@testing-library/react';
 import { ThemeProvider } from 'styled-components';
 import theme from './theme';
 
-const Wrapper = ({ children }) => (
-  <ThemeProvider theme={theme}>
-    {children}
-  </ThemeProvider>
+const renderWithWrapper = (
+  ui,
+  { history = createMemoryHistory() } = {},
+) => (
+  {
+    ...render(
+      <Router history={history}>
+        <ThemeProvider theme={theme}>
+          {ui}
+        </ThemeProvider>
+      </Router>,
+    ),
+    history,
+  }
 );
-
-const renderWithWrapper = (ui, options) => render(ui, { wrapper: Wrapper, ...options });
 
 export * from '@testing-library/react';
 export { renderWithWrapper as render };


### PR DESCRIPTION
The following changes have been made according to the acceptance criteria:
- add Footer component that includes links to profy.dev and terms, along with the logo mark.
- add tests for Footer and Logo components
- update tests for Header component
- add router history to test render wrapper for easier testing

Presently, the AC wants the profy.dev footer link to point to https://profy.dev/employers which gives a 404 at the moment.